### PR TITLE
Add support for PO translations

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -1,0 +1,5 @@
+src/main/lobjur/main.cljs
+src/main/lobjur/widgets/comments.cljs
+src/main/lobjur/widgets/stories_list_view.cljs
+src/main/lobjur/widgets/user
+src/main/rollui/core.cljs

--- a/po/README.md
+++ b/po/README.md
@@ -1,0 +1,16 @@
+# Translating
+## Using POEdit
+To create a new translation of Lobjur you can use POEdit:
+- Install POEdit from a Flatpak: `flatpak install flathub net.poedit.Poedit`; otherwise use your distribution's repositories;
+- Open POEdit and select `Create new translation from POT file`;
+- In the file selection dialog, select the `com.ranfdev.Lobjur.pot` file in the repository's `po` directory;
+- Once you have finished translating, open a pull request from your forked repository to the source repository on the `develop` branch.
+
+---
+
+## Updating the source
+Whenever you add or update a translation, update the source translation from source code changes with this command in the project's root directory:
+
+`xgettext --from-code=UTF-8  --add-comments --keyword=_ --keyword=C_:1c,2 --output=po/com.ranfdev.Lobjur.pot -f po/POTFILES`
+
+Thank you for translating.

--- a/po/com.ranfdev.Lobjur.pot
+++ b/po/com.ranfdev.Lobjur.pot
@@ -1,0 +1,70 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-08-16 10:55-0300\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: src/main/lobjur/main.cljs:59
+msgid "Comments"
+msgstr ""
+
+#: src/main/lobjur/main.cljs:126
+msgid "Command line arguments are: "
+msgstr ""
+
+#: src/main/lobjur/widgets/comments.cljs:121
+msgid "No comments available"
+msgstr ""
+
+#: src/main/lobjur/widgets/stories_list_view.cljs:109
+msgid "No Stories Available"
+msgstr ""
+
+#: src/main/lobjur/widgets/stories_list_view.cljs:117
+msgid "Previous"
+msgstr ""
+
+#: src/main/lobjur/widgets/stories_list_view.cljs:127
+msgid "Next"
+msgstr ""
+
+#: src/main/lobjur/widgets/stories_list_view.cljs:134
+msgid "Hottest"
+msgstr ""
+
+#: src/main/lobjur/widgets/stories_list_view.cljs:137
+msgid "Active"
+msgstr ""
+
+#: src/main/lobjur/widgets/user.cljs:65
+msgid "Karma: "
+msgstr ""
+
+#: src/main/lobjur/widgets/user.cljs:69
+msgid "Newest Stories"
+msgstr ""
+
+#: src/main/rollui/core.cljs:25
+msgid "Error in promise, in update-prop-many"
+msgstr ""
+
+#: src/main/rollui/core.cljs:37
+msgid "Can't build widget with constructor"
+msgstr ""
+
+#: src/main/rollui/core.cljs:38
+msgid "The constructor arguments were"
+msgstr ""


### PR DESCRIPTION
I have  added basic support for PO translations to the project, having taken the liberty to point to a `develop` branch for future submissions in the README. I am already preparing a Brazilian Portuguese translation too; it shouldn't take too long, as there are very few strings to translate. 