### PR TITLE
Bump to supported runtime

### DIFF
--- a/com.ranfdev.Lobjur.json
+++ b/com.ranfdev.Lobjur.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "com.ranfdev.Lobjur",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "42",
+    "runtime-version" : "44",
     "sdk" : "org.gnome.Sdk",
     "command" : "lobjur",
     "finish-args" : [

--- a/src/main/lobjur/main.cljs
+++ b/src/main/lobjur/main.cljs
@@ -145,7 +145,7 @@
     (.present win))
   (Gtk/StyleContext.add_provider_for_display
    (Gdk/Display.get_default)
-   (doto (new Gtk/CssProvider) (.load_from_data (ByteArray/fromString app-css)))
+   (doto (new Gtk/CssProvider) (.load_from_data app-css -1))
    600)
   (state/send [:init]))
 


### PR DESCRIPTION
Bumps to the latest gnome runtime to fix:

```bash
Info: runtime org.gnome.Platform branch 42 is end-of-life, with reason:
   The GNOME 42 runtime is no longer supported as of March 21, 2023. Please ask your application developer to migrate to a supported platform.
```