### PR TITLE
Metainfo improvement: Add device support metadata

### DIFF
--- a/data/com.ranfdev.Lobjur.metainfo.xml
+++ b/data/com.ranfdev.Lobjur.metainfo.xml
@@ -59,6 +59,11 @@
     </release>
   </releases>
 
+  <recommends>
+    <control>keyboard</control>
+    <control>pointing</control>
+    <control>touch</control>
+  </recommends>
   <requires>
     <display_length compare="ge">360</display_length>
   </requires>


### PR DESCRIPTION
Thank you, @ranfdev , for creating this nice app!

This PR will (after a subsequent release) make Lobjur show up in Flathub's Mobile Collection: https://flathub.org/en/apps/collection/mobile/1

See [https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/\#desktop-and-mobile-apps](https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/%5C#desktop-and-mobile-apps) for further information regarding the change.