### PR TITLE
manifest: bump to GNOME 49 runtime

### DIFF
--- a/com.ranfdev.Lobjur.json
+++ b/com.ranfdev.Lobjur.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "com.ranfdev.Lobjur",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "44",
+    "runtime-version" : "49",
     "sdk" : "org.gnome.Sdk",
     "command" : "lobjur",
     "finish-args" : [
@@ -26,8 +26,8 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://github.com/ranfdev/Lobjur/releases/download/v1.0.1/com.ranfdev.Lobjur.tar.xz",
-                    "sha256": "6d462d30b34b475ade8b7037ce569a4e4e6f187445920c1590a44efdcad8da7d",
+                    "url" : "https://github.com/ranfdev/Lobjur/releases/download/v1.3.0/com.ranfdev.Lobjur.tar.xz",
+                    "sha256": "c0ada0510613cccec2a798d0200e8a69ed2c013b99388cdec9b2a0cece46e922",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/ranfdev/Lobjur/releases/latest",


### PR DESCRIPTION
Hi @ranfdev,, 
thanks again for creating the app - this just updates the flatpak manifest to stay in line with https://github.com/flathub/com.ranfdev.Lobjur/pull/7. 

The app appears to launch and load posts fine with the latest runtime.
Comments do not load, but the current app with the unmaintained runtime shows a similar behavior. I have asked Claude code to fix this (see https://github.com/ranfdev/Lobjur/commit/a8b923f5ca32502a811cc24c378929d9b6d87a44 for its 'fix'), but could not test that suggestion since I don't understand how to actually build this app from source.

Don't worry: This PR and https://github.com/ranfdev/Lobjur/pull/11 are handwritten and thought out entirely by a human (with, frankly, not much thought necessary).

I hope this helps!

Cheers,
Peter