### PR TITLE
Update metainfo to follow Flathub guidelines

### DIFF
--- a/data/com.ranfdev.Lobjur.metainfo.xml
+++ b/data/com.ranfdev.Lobjur.metainfo.xml
@@ -5,7 +5,11 @@
   <metadata_license>CC0</metadata_license>
   <project_license>GPL-3.0+</project_license>
   <name>Lobjur</name>
-  <summary>Native GNOME client for Lobsters and Hacker News</summary>
+  <summary>Browse Lobsters and Hacker News</summary>
+  <branding>
+	<color type="primary" scheme_preference="light">#ce5050</color>
+	<color type="primary" scheme_preference="dark">#c15327</color>
+  </branding>
   <description>
     <p>Native GNOME client for Lobsters and Hacker News, featuring multiple feeds, collapsible comments, and an integrated web view.</p>
   </description>


### PR DESCRIPTION
I saw that this app was close to meeting Flathub’s metadata quality guidelines. It was only missing brand colors and had some issues with the summary, so I fixed them for you. Meeting these guidelines makes it more likely that your app will be featured on Flathub.

Make sure to request a re-review after this patch makes it into a Flathub release.

<img width="1401" height="931" alt="image" src="https://github.com/user-attachments/assets/eab8dee1-0829-461a-abe2-920e13b7479b" />
